### PR TITLE
Hawkular-177 : Add dependencies to get rid of missing class errors in server log

### DIFF
--- a/accounts/pom.xml
+++ b/accounts/pom.xml
@@ -109,12 +109,20 @@
       <groupId>com.mattbertolini</groupId>
       <artifactId>liquibase-slf4j</artifactId>
     </dependency>
-
+      <!-- liquibase really should have transitive deps that get imported but it seems that we
+           need to package junit and jetty-server to avoid spamming the server log with missing
+           class errors at runtime. Note, junit is also needed for test -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <!--  <scope>test</scope>  -->
     </dependency>
+
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>

--- a/accounts/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/accounts/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<jboss-deployment-structure>
+  <deployment>
+    <dependencies>
+      <!-- This is here only because liquibase is looking for classes and Wfly has them in a standard module -->
+      <module name="org.yaml.snakeyaml" />
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,19 @@
         <artifactId>liquibase-slf4j</artifactId>
         <version>1.2.1</version>
       </dependency>
+      <!-- liquibase really should have transitive deps that get imported but it seems that we
+           need to package junit and jetty-server to avoid spamming the server log with missing
+           class errors at runtime -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>9.2.10.v20150310</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
 
       <dependency>
         <groupId>com.h2database</groupId>


### PR DESCRIPTION
This may not be the preferred approach because it packages more jars in
the war, but it is a working option.
