### PR TITLE
[HAWKULAR-943] enable confirmation-window-size so async sends are ack'd

### DIFF
--- a/feature-pack-resources/src/main/xsl/subsystem-templates/hawkular-accounts-messaging-activemq.xsl
+++ b/feature-pack-resources/src/main/xsl/subsystem-templates/hawkular-accounts-messaging-activemq.xsl
@@ -33,6 +33,7 @@
     <xsl:copy select=".">
       <xsl:apply-templates select="@*|node()" />
       <xsl:attribute name="entries"><xsl:value-of select="@entries"/> java:/HawkularBusConnectionFactory</xsl:attribute>
+      <xsl:attribute name="confirmation-window-size">10024</xsl:attribute>
     </xsl:copy>
   </xsl:template>
 


### PR DESCRIPTION
Enabling this setting will eliminate the warnings that are flooding the logs. I am defaulting the buffer size to 10 KB. This change is made in accounts since the bus connection factory is generated and configured in the accounts feature pack.
