### PR TITLE
This is a regression of HAWKULAR-372

### DIFF
--- a/feature-pack/src/main/resources/content/standalone/configuration/hawkular-realm-for-dev.json
+++ b/feature-pack/src/main/resources/content/standalone/configuration/hawkular-realm-for-dev.json
@@ -87,8 +87,8 @@
       "bearerOnly" : false,
       "publicClient": false,
       "directAccessGrantsEnabled" : true,
-      "redirectUris": ["/*", "http://localhost:2772/*", "http://localhost:3000/*"],
-      "webOrigins": ["http://localhost:2772","http://localhost:3000"],
+      "redirectUris": ["/*", "http://localhost:2772/*", "http://localhost:3000/*", "http://localhost:9876/*"],
+      "webOrigins": ["http://localhost:2772", "http://localhost:3000", "http://localhost:9876"],
       "secret" : "${uuid.hawkular.accounts.backend}"
     },
     {
@@ -101,11 +101,13 @@
       "redirectUris": [
         "/*",
         "http://localhost:2772/*",
-        "http://localhost:3000/*"
+        "http://localhost:3000/*",
+        "http://localhost:9876/"
       ],
       "webOrigins": [
         "http://localhost:2772",
-        "http://localhost:3000"
+        "http://localhost:3000",
+        "http://localhost:9876"
       ],
       "claims": {
         "username": true,


### PR DESCRIPTION
tests in ui-services are being run in PhantomJS, it's running on port 9876 and the Origin header can't be overriden to, say, 8080.
