### PR TITLE
Inherit datasources from Nest

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -203,6 +203,12 @@
                   <artifactId>wildfly-security</artifactId>
                   <version>${version.org.wildfly}</version>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.hawkular.commons</groupId>
+                  <artifactId>hawkular-nest-feature-pack</artifactId>
+                  <version>${version.org.hawkular.commons}</version>
+                  <type>zip</type>
+                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>
@@ -260,6 +266,20 @@
                   <fileMappers>
                     <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
                       <pattern>^subsystem-templates/(.*)\.xml$</pattern>
+                      <replacement>subsystem-templates/hawkular-accounts-$1.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+                <transformationSet>
+                  <dir>${project.build.directory}/upstream-subsystem-templates</dir>
+                  <stylesheet>${basedir}/src/main/xsl/subsystem-templates/hawkular-accounts-datasources.xsl</stylesheet>
+                  <includes>
+                    <include>subsystem-templates/hawkular-nest-datasources.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/${project.artifactId}-${project.version}</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^subsystem-templates/.*-(.*)\.xml$</pattern>
                       <replacement>subsystem-templates/hawkular-accounts-$1.xml</replacement>
                     </fileMapper>
                   </fileMappers>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@
     <subsystem>logging.xml</subsystem>
     <subsystem>batch.xml</subsystem>
     <subsystem>bean-validation.xml</subsystem>
-    <subsystem>keycloak-datasources.xml</subsystem>
+    <subsystem>hawkular-accounts-datasources.xml</subsystem>
     <subsystem>ee.xml</subsystem>
     <subsystem>hawkular-accounts-ejb3.xml</subsystem>
     <subsystem>io.xml</subsystem>

--- a/feature-pack/src/main/xsl/subsystem-templates/hawkular-accounts-datasources.xsl
+++ b/feature-pack/src/main/xsl/subsystem-templates/hawkular-accounts-datasources.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+  <xsl:strip-space elements="*" />
+
+  <!-- //*[local-name()='config']/*[local-name()='supplement' and @name='default'] is an xPath's 1.0
+       way of saying of xPath's 2.0 prefix-less selector //*:config/*:supplement[@name='default']  -->
+  <xsl:template match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='datasources']">
+    <xsl:copy>
+      <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+        <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+        <driver>h2</driver>
+        <security>
+          <user-name>sa</user-name>
+          <password>sa</password>
+        </security>
+      </datasource>
+
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
   </distributionManagement>
 
   <properties>
-    <version.org.hawkular.commons>0.3.5.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.3.6.Final-SRC-revision-c08c21db19f4f00056e5c4aeb700354f2c5ee1e1</version.org.hawkular.commons>
     <version.org.keycloak.secretstore>1.0.12.Final</version.org.keycloak.secretstore>
 
     <!-- Accounts should be the only place where the KeyCloak version is defined -->


### PR DESCRIPTION
This builds on top of 9fb1beb1a6ec902476ff0876c522670eef8c9715 (PR #128) and changes the way KeycloakDS is defined.

We used to just inherit the datasources from keycloak, now we inherit the  datasources from nest and add keycloak-specific DS to those.

NOTE: this depends on https://github.com/hawkular/hawkular-commons/pull/44
